### PR TITLE
Add simple React chat app with OpenAI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# manaboo
-Personal Japanese Learning Application
+# Manaboo Chat App
+
+This project is a small React-based web application that lets you send a prompt to OpenAI and display the answer on the page. The front-end is served by a simple Express server.
+
+## Setup
+
+1. Install dependencies (requires Node.js >= 18):
+
+   ```bash
+   npm install
+   ```
+
+2. Set the `OPENAI_API_KEY` environment variable to your OpenAI API key.
+
+3. Start the server:
+
+   ```bash
+   npm start
+   ```
+
+4. Open `http://localhost:3000` in your browser.
+
+Type a question in the textarea and press **Ask** to get a response from OpenAI.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "manaboo-chat-app",
+  "version": "1.0.0",
+  "main": "server.js",
+  "license": "MIT",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>OpenAI Q&A</title>
+  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    function ChatApp() {
+      const [question, setQuestion] = React.useState('');
+      const [answer, setAnswer] = React.useState('');
+      const [loading, setLoading] = React.useState(false);
+
+      const submitQuestion = async () => {
+        if (!question.trim()) return;
+        setLoading(true);
+        try {
+          const resp = await fetch('/api/ask', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ question })
+          });
+          const data = await resp.json();
+          if (data.answer) {
+            setAnswer(data.answer);
+          } else if (data.error) {
+            setAnswer('Error: ' + data.error);
+          }
+        } catch (err) {
+          setAnswer('Error: ' + err.message);
+        } finally {
+          setLoading(false);
+        }
+      };
+
+      return (
+        <div>
+          <h1>OpenAI Q&A</h1>
+          <textarea value={question} onChange={e => setQuestion(e.target.value)} rows="4" cols="50" />
+          <br />
+          <button onClick={submitQuestion} disabled={loading}>Ask</button>
+          <h2>Answer:</h2>
+          <pre>{answer}</pre>
+        </div>
+      );
+    }
+
+    ReactDOM.render(<ChatApp />, document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+app.use(express.static('public'));
+app.use(express.json());
+
+app.post('/api/ask', async (req, res) => {
+  if (!OPENAI_API_KEY) {
+    return res.status(500).json({ error: 'Missing OPENAI_API_KEY' });
+  }
+  const { question } = req.body;
+  if (!question) {
+    return res.status(400).json({ error: 'No question provided' });
+  }
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${OPENAI_API_KEY}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: question }]
+      })
+    });
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(500).json({ error: errorText });
+    }
+    const data = await response.json();
+    const answer = data.choices[0].message.content.trim();
+    res.json({ answer });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- set up Express server and React client
- connect to OpenAI API using `/api/ask`
- document usage in README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684279382414832dbafbf89550002e80